### PR TITLE
🐛 YAxis when average greater than max

### DIFF
--- a/src/pages/IndexedDailyPrices/index.jsx
+++ b/src/pages/IndexedDailyPrices/index.jsx
@@ -7,6 +7,7 @@ import {
   transformIndexedTariffPrices,
   computeTotals,
   dayIsMissing,
+  computeMaxYAxisValue,
 } from '../../services/utils'
 import TariffSelector from '../../components/TariffSelector'
 import { useTariffNameContext } from '../../components/TariffNameContextProvider'
@@ -80,6 +81,8 @@ export default function IndexedDailyPrices() {
       }),
     },
   ]
+
+  const tickCountValue = 7 // Number of yAxis values
 
   const [error, setError] = useState(false)
 
@@ -158,6 +161,8 @@ export default function IndexedDailyPrices() {
             legend={true}
             showTooltipKeys={false}
             referenceLineData={referenceLineData}
+            tickCount={tickCountValue}
+            maxYAxisValue={computeMaxYAxisValue(totalPrices, tickCountValue)}
           />
           <Box sx={{ marginTop: '40px' }}>
             <SumPricesDisplay totalPrices={totalPricesData} />

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -225,3 +225,12 @@ export function dayIsMissing(periods) {
   }
   return true
 }
+
+export function computeMaxYAxisValue(totalPrices, tickCount = 7) {
+  let maxYAxisValue = 'auto'
+  let weekly_average_price = parseFloat(totalPrices['WEEKLY_AVERAGE'].replace(',','.'))
+  let max_price = parseFloat(totalPrices['MAX'].replace(',','.'))
+  if (weekly_average_price > max_price)
+    maxYAxisValue = parseFloat(parseFloat(weekly_average_price + weekly_average_price / tickCount).toFixed(2))
+  return maxYAxisValue
+}

--- a/src/services/utils.test.js
+++ b/src/services/utils.test.js
@@ -5,6 +5,7 @@ import {
   transformIndexedTariffPrices,
   dayIsMissing,
   weekTimeInterval,
+  computeMaxYAxisValue,
 } from './utils'
 
 describe('getPricesForPeriod', () => {
@@ -237,6 +238,53 @@ describe('weekTimeInterval', () => {
         new Date('2023-10-23T00:00:00'),
         new Date('2023-10-30T00:00:00'),
       ])
+    })
+  })
+})
+
+describe('computeMaxYAxisValue', () => {
+  describe('when weekly average price is lower than daily maximum price', () => {
+    it('returns the default behavior', () => {
+      const weekly_average_price = '2,00'
+      const daily_maximum_price = '4,00'
+      const totalPrices = {
+        WEEKLY_AVERAGE: weekly_average_price,
+        MAX: daily_maximum_price
+      }
+
+      const result = computeMaxYAxisValue(totalPrices)
+
+      expect(result).toStrictEqual('auto')
+    })
+  })
+  describe('when weekly average price is equal to daily maximum price', () => {
+    it('returns the default behavior', () => {
+      const weekly_average_price = '2,00'
+      const daily_maximum_price = '2.00'
+      const totalPrices = {
+        WEEKLY_AVERAGE: weekly_average_price,
+        MAX: daily_maximum_price
+      }
+
+      const result = computeMaxYAxisValue(totalPrices)
+
+      expect(result).toStrictEqual('auto')
+    })
+  })
+  describe('when weekly average price is greater than daily maximum price', () => {
+    it('returns the default behavior', () => {
+      const weekly_average_price = '4,00'
+      const daily_maximum_price = '2,00'
+      const tickCount = 7
+      const totalPrices = {
+        WEEKLY_AVERAGE: weekly_average_price,
+        MAX: daily_maximum_price
+      }
+
+      const result = computeMaxYAxisValue(totalPrices, tickCount)
+
+      const expectedResult = 4.57
+      expect(result).toStrictEqual(expectedResult)
     })
   })
 })


### PR DESCRIPTION
## Description
Average line is not shown when average value greater than max value

## Changes

- Calculate the max Y axis value depending n average and max values

## Checklist

Justify any unchecked point:

- [X] Changed code is covered by tests.
- [ ] Relevant changes are explained in the "Unreleased" section of the `CHANGES.md` file.
- [ ] That section includes "Upgrade notes" with any config, dependency or deploy tweek needed on development and server setups.
- [ ] Changes on the setup process (development, testing, production) have been updated in the proper documentation

